### PR TITLE
feat: implement agent-browser integration module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,9 @@
 
 ## Package Manager
 Always use `pnpm` instead of `npm` or `yarn`.
+
+## Git Workflow
+Always create a pull request for changes. Never push directly to main.
+
+## Language
+Always use English in code, comments, and commit messages.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "tsx src/index.tsx",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "tsx src/browser.test.ts"
   },
   "dependencies": {
     "ink": "^5.0.1",

--- a/src/browser.test.ts
+++ b/src/browser.test.ts
@@ -1,0 +1,47 @@
+import { Browser } from './browser';
+
+async function test() {
+  const browser = new Browser();
+
+  // Test open and snapshot
+  await browser.open('data:text/html,<h1>Hello</h1>');
+  let tree = await browser.snapshot({ compact: true });
+  console.log('Snapshot:', tree);
+  if (!tree.includes('Hello')) throw new Error('Expected "Hello" in snapshot');
+
+  // Test navigation info
+  const url = await browser.getUrl();
+  console.log('URL:', url);
+  if (!url.includes('data:text/html')) throw new Error('Expected data URL');
+
+  // Test form interaction
+  await browser.open('data:text/html,<input id="email" placeholder="Email">');
+  tree = await browser.snapshot({ interactive: true });
+  console.log('Form snapshot:', tree);
+
+  // Find the input ref from snapshot
+  const match = tree.match(/ref=(e\d+)/);
+  if (!match) throw new Error('Could not find input ref');
+  const ref = match[1];
+
+  await browser.fill(ref, 'test@example.com');
+  const value = await browser.getText(ref);
+  console.log('Input value:', value);
+
+  // Test click
+  await browser.open('data:text/html,<button id="btn">Click me</button>');
+  tree = await browser.snapshot({ interactive: true });
+  const btnMatch = tree.match(/ref=(e\d+)/);
+  if (!btnMatch) throw new Error('Could not find button ref');
+  await browser.click(btnMatch[1]);
+  console.log('Click: OK');
+
+  // Cleanup
+  await browser.close();
+  console.log('All tests passed!');
+}
+
+test().catch((err) => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,122 @@
+import { exec as execCallback } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(execCallback);
+
+export class BrowserError extends Error {
+  constructor(
+    message: string,
+    public command: string,
+    public stderr: string
+  ) {
+    super(message);
+    this.name = 'BrowserError';
+  }
+}
+
+export interface SnapshotOptions {
+  interactive?: boolean;
+  compact?: boolean;
+  depth?: number;
+  selector?: string;
+}
+
+export class Browser {
+  private session: string;
+
+  constructor(sessionName?: string) {
+    this.session = sessionName ?? `tok-${Date.now()}`;
+  }
+
+  private async exec(command: string): Promise<string> {
+    const fullCommand = `agent-browser --session ${this.session} ${command}`;
+    try {
+      const { stdout } = await execAsync(fullCommand);
+      return stdout.trim();
+    } catch (error) {
+      const err = error as { stderr?: string; message?: string };
+      const stderr = err.stderr?.trim() || err.message || 'Unknown error';
+      throw new BrowserError(`agent-browser command failed: ${stderr}`, fullCommand, stderr);
+    }
+  }
+
+  // Core
+  async open(url: string): Promise<void> {
+    await this.exec(`open '${url}'`);
+  }
+
+  async snapshot(options?: SnapshotOptions): Promise<string> {
+    const flags: string[] = [];
+    if (options?.interactive) flags.push('-i');
+    if (options?.compact) flags.push('-c');
+    if (options?.depth !== undefined) flags.push(`-d ${options.depth}`);
+    if (options?.selector) flags.push(`-s '${options.selector}'`);
+    return this.exec(`snapshot ${flags.join(' ')}`);
+  }
+
+  async click(ref: string): Promise<void> {
+    await this.exec(`click @${ref}`);
+  }
+
+  async fill(ref: string, value: string): Promise<void> {
+    const escaped = value.replace(/'/g, "'\\''");
+    await this.exec(`fill @${ref} '${escaped}'`);
+  }
+
+  async close(): Promise<void> {
+    await this.exec('close');
+  }
+
+  // Navigation
+  async back(): Promise<void> {
+    await this.exec('back');
+  }
+
+  async forward(): Promise<void> {
+    await this.exec('forward');
+  }
+
+  async reload(): Promise<void> {
+    await this.exec('reload');
+  }
+
+  async scroll(direction: 'up' | 'down' | 'left' | 'right', pixels?: number): Promise<void> {
+    const args = pixels !== undefined ? `${direction} ${pixels}` : direction;
+    await this.exec(`scroll ${args}`);
+  }
+
+  async wait(selectorOrMs: string | number): Promise<void> {
+    await this.exec(`wait ${selectorOrMs}`);
+  }
+
+  // Interaction
+  async type(ref: string, text: string): Promise<void> {
+    const escaped = text.replace(/'/g, "'\\''");
+    await this.exec(`type @${ref} '${escaped}'`);
+  }
+
+  async press(key: string): Promise<void> {
+    await this.exec(`press ${key}`);
+  }
+
+  async hover(ref: string): Promise<void> {
+    await this.exec(`hover @${ref}`);
+  }
+
+  // Info
+  async screenshot(path?: string): Promise<string> {
+    return this.exec(path ? `screenshot '${path}'` : 'screenshot');
+  }
+
+  async getTitle(): Promise<string> {
+    return this.exec('get title');
+  }
+
+  async getUrl(): Promise<string> {
+    return this.exec('get url');
+  }
+
+  async getText(ref: string): Promise<string> {
+    return this.exec(`get text @${ref}`);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `Browser` class wrapping agent-browser CLI with async execution
- Session management ensures all commands target the same browser instance
- Full interaction set: open, snapshot, click, fill, close, navigation, type, press, hover, screenshot, getTitle, getUrl, getText
- `BrowserError` class for typed error handling
- Integration tests using `data:` URLs (no network required)

## Test plan
- [x] `pnpm test` passes
- [ ] Manual verification with real URLs

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)