### PR TITLE
feat: implement snapshot parser

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { parseSnapshot } from "./parser.js";
+
+describe("parseSnapshot", () => {
+  it("parses simple heading", () => {
+    const raw = '- heading "Example Domain" [level=1, ref=e1]';
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      type: "heading",
+      name: "Example Domain",
+      level: 1,
+      ref: "e1",
+    });
+  });
+
+  it("parses nested structure", () => {
+    const raw = `- paragraph
+  - StaticText "Hello world"
+  - link "Learn more" [ref=e1]`;
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.type).toBe("paragraph");
+    expect(result[0]?.children).toHaveLength(2);
+    expect(result[0]?.children[0]).toMatchObject({
+      type: "StaticText",
+      name: "Hello world",
+    });
+    expect(result[0]?.children[1]).toMatchObject({
+      type: "link",
+      name: "Learn more",
+      ref: "e1",
+    });
+  });
+
+  it("parses checkbox with checked attribute", () => {
+    const raw = "- checkbox [checked=true, ref=e1]";
+    const result = parseSnapshot(raw);
+
+    expect(result[0]).toMatchObject({
+      type: "checkbox",
+      checked: true,
+      ref: "e1",
+    });
+  });
+
+  it("parses checkbox with mixed state", () => {
+    const raw = "- checkbox [checked=mixed, ref=e1]";
+    const result = parseSnapshot(raw);
+
+    expect(result[0]?.checked).toBe("mixed");
+  });
+
+  it("parses combobox with value", () => {
+    const raw = "- combobox [expanded=false, ref=e1]: Option B";
+    const result = parseSnapshot(raw);
+
+    expect(result[0]).toMatchObject({
+      type: "combobox",
+      expanded: false,
+      ref: "e1",
+      value: "Option B",
+    });
+  });
+
+  it("parses option with selected", () => {
+    const raw = '- option "B" [selected, ref=e1]';
+    const result = parseSnapshot(raw);
+
+    expect(result[0]).toMatchObject({
+      type: "option",
+      name: "B",
+      selected: true,
+      ref: "e1",
+    });
+  });
+
+  it("parses button with disabled", () => {
+    const raw = '- button "Submit" [disabled, ref=e1]';
+    const result = parseSnapshot(raw);
+
+    expect(result[0]).toMatchObject({
+      type: "button",
+      name: "Submit",
+      disabled: true,
+      ref: "e1",
+    });
+  });
+
+  it("parses multiple roots", () => {
+    const raw = `- heading "Title" [level=1, ref=e1]
+- paragraph
+  - StaticText "Content"
+- link "More" [ref=e2]`;
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]?.type).toBe("heading");
+    expect(result[1]?.type).toBe("paragraph");
+    expect(result[2]?.type).toBe("link");
+  });
+
+  it("handles deeply nested structure", () => {
+    const raw = `- navigation
+  - list
+    - listitem
+      - link "Home" [ref=e1]
+    - listitem
+      - link "About" [ref=e2]`;
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.type).toBe("navigation");
+    expect(result[0]?.children[0]?.type).toBe("list");
+    expect(result[0]?.children[0]?.children).toHaveLength(2);
+    expect(result[0]?.children[0]?.children[0]?.children[0]).toMatchObject({
+      type: "link",
+      name: "Home",
+      ref: "e1",
+    });
+  });
+
+  it("handles empty input", () => {
+    const result = parseSnapshot("");
+    expect(result).toHaveLength(0);
+  });
+
+  it("parses real agent-browser output", () => {
+    const raw = `- heading "Example Domain" [level=1, ref=e1]
+- paragraph
+  - StaticText "This domain is for use in documentation examples."
+- paragraph
+  - link "Learn more" [ref=e2]`;
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({
+      type: "heading",
+      name: "Example Domain",
+      level: 1,
+      ref: "e1",
+    });
+    expect(result[2]?.children[0]).toMatchObject({
+      type: "link",
+      name: "Learn more",
+      ref: "e2",
+    });
+  });
+
+  it("parses form elements", () => {
+    const raw = `- textbox "Name" [ref=e1]
+- checkbox [checked=true, ref=e2]
+- combobox [expanded=false, ref=e3]: B
+  - option "A" [ref=e5]
+  - option "B" [selected, ref=e6]
+- button "Submit" [disabled, ref=e4]`;
+    const result = parseSnapshot(raw);
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatchObject({ type: "textbox", name: "Name", ref: "e1" });
+    expect(result[1]).toMatchObject({ type: "checkbox", checked: true, ref: "e2" });
+    expect(result[2]).toMatchObject({
+      type: "combobox",
+      expanded: false,
+      ref: "e3",
+      value: "B",
+    });
+    expect(result[2]?.children).toHaveLength(2);
+    expect(result[2]?.children[1]).toMatchObject({
+      type: "option",
+      name: "B",
+      selected: true,
+      ref: "e6",
+    });
+    expect(result[3]).toMatchObject({
+      type: "button",
+      name: "Submit",
+      disabled: true,
+      ref: "e4",
+    });
+  });
+});

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,107 @@
+export interface SnapshotNode {
+  type: string;
+  name?: string;
+  ref?: string;
+  level?: number;
+  checked?: boolean | "mixed";
+  expanded?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+  required?: boolean;
+  value?: string;
+  children: SnapshotNode[];
+}
+
+interface ParsedLine {
+  indent: number;
+  node: SnapshotNode;
+}
+
+function parseLine(line: string): ParsedLine | null {
+  // Count indent (2 spaces = 1 level)
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith("- ")) return null;
+
+  const indent = (line.length - trimmed.length) / 2;
+  const content = trimmed.slice(2); // Remove "- "
+
+  // Parse: {type} ["name"] [{attrs}] [: value]
+  const node: SnapshotNode = { type: "", children: [] };
+
+  // Extract type (first word)
+  const typeMatch = content.match(/^(\w+)/);
+  if (!typeMatch?.[1]) return null;
+  node.type = typeMatch[1];
+
+  let rest = content.slice(typeMatch[0].length).trim();
+
+  // Extract quoted name
+  if (rest.startsWith('"')) {
+    const nameMatch = rest.match(/^"((?:[^"\\]|\\.)*)"/);
+    if (nameMatch?.[1] !== undefined) {
+      node.name = nameMatch[1].replace(/\\"/g, '"').replace(/\\n/g, "\n");
+      rest = rest.slice(nameMatch[0].length).trim();
+    }
+  }
+
+  // Extract value after ": " (before parsing attrs, as value comes at the end)
+  const valueMatch = rest.match(/:\s*(.+)$/);
+  if (valueMatch?.[1]) {
+    node.value = valueMatch[1].trim();
+    rest = rest.slice(0, rest.length - valueMatch[0].length).trim();
+  }
+
+  // Extract attributes [key=value, key2, ...]
+  const attrMatch = rest.match(/\[([^\]]+)\]/);
+  if (attrMatch?.[1]) {
+    const attrs = attrMatch[1].split(",").map((a) => a.trim());
+    for (const attr of attrs) {
+      if (attr.startsWith("ref=")) {
+        node.ref = attr.slice(4);
+      } else if (attr.startsWith("level=")) {
+        node.level = parseInt(attr.slice(6), 10);
+      } else if (attr.startsWith("checked=")) {
+        const val = attr.slice(8);
+        node.checked = val === "mixed" ? "mixed" : val === "true";
+      } else if (attr.startsWith("expanded=")) {
+        node.expanded = attr.slice(9) === "true";
+      } else if (attr === "selected") {
+        node.selected = true;
+      } else if (attr === "disabled") {
+        node.disabled = true;
+      } else if (attr === "required") {
+        node.required = true;
+      }
+    }
+  }
+
+  return { indent, node };
+}
+
+export function parseSnapshot(raw: string): SnapshotNode[] {
+  const lines = raw.split("\n").filter((line) => line.trim());
+  const roots: SnapshotNode[] = [];
+  const stack: { indent: number; node: SnapshotNode }[] = [];
+
+  for (const line of lines) {
+    const parsed = parseLine(line);
+    if (!parsed) continue;
+
+    const { indent, node } = parsed;
+
+    // Pop stack until we find the parent
+    while (stack.length > 0 && stack[stack.length - 1]!.indent >= indent) {
+      stack.pop();
+    }
+
+    if (stack.length === 0) {
+      roots.push(node);
+    } else {
+      stack[stack.length - 1]!.node.children.push(node);
+    }
+
+    stack.push({ indent, node });
+  }
+
+  return roots;
+}


### PR DESCRIPTION
## Summary
- Add `SnapshotNode` type with all properties from agent-browser snapshot
- Implement `parseSnapshot()` to parse text into nested tree structure
- Handle indentation-based nesting, quoted names, attributes `[key=value]`, and values after `:`
- Comprehensive unit tests for various snapshot formats

## Design notes
- Parser is designed to be easily replaceable if agent-browser adds native JSON output
- Tree structure uses nested `children` array (matches agent-browser internal structure)

## Test plan
- [x] Unit tests pass (12 test cases)
- [x] Typecheck passes
- [ ] CI passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)