### PR TITLE
feat: implement content renderer

### DIFF
--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -235,4 +235,32 @@ describe("render", () => {
     expect(result.lines).toContainEqual({ text: "[2] Sign In", interactive: true, number: 2 });
     expect(result.numberToRef).toEqual({ 1: "e2", 2: "e3" });
   });
+
+  it("renders interactive element without ref as plain text", () => {
+    const nodes: SnapshotNode[] = [
+      { type: "link", name: "Link without ref", children: [] },
+      { type: "button", name: "Button with ref", ref: "e1", children: [] },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toContainEqual({ text: "Link without ref", interactive: false });
+    expect(result.lines).toContainEqual({
+      text: "[1] Button with ref",
+      interactive: true,
+      number: 1,
+    });
+    expect(result.numberToRef).toEqual({ 1: "e1" });
+  });
+
+  it("does not assign number to interactive element without ref", () => {
+    const nodes: SnapshotNode[] = [
+      { type: "textbox", name: "Name", children: [] },
+      { type: "checkbox", name: "Agree", children: [] },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toContainEqual({ text: "Name", interactive: false });
+    expect(result.lines).toContainEqual({ text: "Agree", interactive: false });
+    expect(Object.keys(result.numberToRef)).toHaveLength(0);
+  });
 });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -148,7 +148,7 @@ function renderNode(node: SnapshotNode, ctx: RenderContext): void {
     return;
   }
 
-  // Handle interactive elements
+  // Handle interactive elements with ref
   if (isInteractive(node)) {
     const number = ctx.nextNumber++;
     ctx.numberToRef[number] = node.ref!;
@@ -158,6 +158,18 @@ function renderNode(node: SnapshotNode, ctx: RenderContext): void {
       number,
     });
     // Render children (e.g., options in combobox)
+    for (const child of node.children) {
+      renderNode(child, ctx);
+    }
+    return;
+  }
+
+  // Handle interactive elements without ref - display as plain text
+  if (INTERACTIVE_TYPES.has(node.type)) {
+    const text = node.name ?? "";
+    if (text) {
+      ctx.lines.push({ text, interactive: false });
+    }
     for (const child of node.children) {
       renderNode(child, ctx);
     }


### PR DESCRIPTION
## Summary
- Add `DisplayLine` and `RenderResult` types
- Implement `render()` to transform `SnapshotNode[]` to human-readable format
- Headings: `# Title` based on level
- Links/buttons: `[N] text`
- Text inputs: `[N] label: [value]`
- Checkboxes: `[N] [x] label`
- Radio buttons: `[N] ● label`
- Combobox/options: `[N] label ▶ value`
- Build `numberToRef` mapping for interaction by number

## Test plan
- [x] Unit tests pass (20 test cases)
- [x] Typecheck passes
- [ ] CI passes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)