### PR TITLE
feat: implement page navigation flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "tok",
   "version": "0.1.0",
+  "bin": {
+    "tok": "./dist/cli.js"
+  },
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.tsx",
+    "dev": "tsx src/cli.tsx",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import React from "react";
+import { render } from "ink";
+import { App } from "./components/App.js";
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    console.log("Usage: tok <url>");
+    console.log("");
+    console.log("A terminal browser powered by agent-browser.");
+    console.log("");
+    console.log("Examples:");
+    console.log("  tok https://news.ycombinator.com");
+    console.log("  tok https://example.com");
+    process.exit(args.length === 0 ? 1 : 0);
+  }
+
+  const url = args[0]!;
+
+  // Basic URL validation
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    console.error(`Invalid URL: ${url}`);
+    console.error("URL must start with http:// or https://");
+    process.exit(1);
+  }
+
+  render(<App url={url} />);
+}
+
+main();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,19 +1,52 @@
-import React from "react";
-import { Box, useStdout } from "ink";
+import React, { useEffect } from "react";
+import { Box, useApp, useStdout } from "ink";
 import { Header } from "./Header.js";
 import { Content } from "./Content.js";
 import { StatusBar } from "./StatusBar.js";
 import { Input } from "./Input.js";
 import { useAppState } from "../state/useAppState.js";
 import { useKeyboard } from "../hooks/useKeyboard.js";
+import { useBrowser } from "../hooks/useBrowser.js";
 
-export function App() {
+export interface AppProps {
+  url?: string;
+}
+
+export function App({ url }: AppProps) {
+  const { exit } = useApp();
   const { stdout } = useStdout();
-  const [state, actions] = useAppState();
+  const [state, actions] = useAppState(url);
+  const { navigate, click, back, cleanup } = useBrowser(state, actions);
 
   const viewportHeight = stdout?.rows ? stdout.rows - 4 : 20;
 
-  useKeyboard(state, actions);
+  useKeyboard(state, actions, {
+    onNavigate: navigate,
+    onClick: (ref) => {
+      click(ref);
+    },
+    onBack: back,
+  });
+
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  useEffect(() => {
+    const handleExit = () => {
+      cleanup().then(() => exit());
+    };
+
+    process.on("SIGINT", handleExit);
+    process.on("SIGTERM", handleExit);
+
+    return () => {
+      process.off("SIGINT", handleExit);
+      process.off("SIGTERM", handleExit);
+    };
+  }, [cleanup, exit]);
 
   return (
     <Box flexDirection="column" height={stdout?.rows}>

--- a/src/hooks/useBrowser.ts
+++ b/src/hooks/useBrowser.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Browser } from "../browser.js";
+import { parseSnapshot } from "../parser.js";
+import { render } from "../renderer.js";
+import type { AppState, InteractiveElement } from "../state/AppState.js";
+import type { AppActions, PageData } from "../state/useAppState.js";
+
+export function useBrowser(
+  state: AppState,
+  actions: AppActions,
+): {
+  navigate: (url: string) => Promise<void>;
+  click: (ref: string) => Promise<void>;
+  back: () => Promise<void>;
+  cleanup: () => Promise<void>;
+} {
+  const browserRef = useRef<Browser | null>(null);
+
+  const getBrowser = useCallback(() => {
+    if (!browserRef.current) {
+      browserRef.current = new Browser();
+    }
+    return browserRef.current;
+  }, []);
+
+  const loadPage = useCallback(async (): Promise<PageData | null> => {
+    const browser = getBrowser();
+    try {
+      const [snapshot, url, title] = await Promise.all([
+        browser.snapshot({ interactive: true }),
+        browser.getUrl(),
+        browser.getTitle(),
+      ]);
+
+      const nodes = parseSnapshot(snapshot);
+      const result = render(nodes);
+
+      const elements: InteractiveElement[] = result.lines
+        .filter((line) => line.interactive && line.number !== undefined)
+        .map((line) => ({
+          ref: result.numberToRef[line.number!]!,
+          label: line.number!,
+          text: line.text.replace(/^\[\d+\]\s*/, ""),
+          type: "link" as const,
+        }));
+
+      return {
+        url,
+        title,
+        elements,
+        totalLines: result.lines.length,
+        numberToRef: result.numberToRef,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      actions.pushStatus(`Error: ${message}`, "error", 5000);
+      return null;
+    }
+  }, [getBrowser, actions]);
+
+  const navigate = useCallback(
+    async (url: string) => {
+      const browser = getBrowser();
+      actions.setLoading(true);
+      actions.pushStatus(`Loading ${url}...`, "loading");
+
+      try {
+        await browser.open(url);
+        const pageData = await loadPage();
+        if (pageData) {
+          actions.setPage(pageData);
+          actions.clearStatus("loading");
+        }
+      } catch (error) {
+        actions.setLoading(false);
+        actions.clearStatus("loading");
+        const message = error instanceof Error ? error.message : "Unknown error";
+        actions.pushStatus(`Failed to load: ${message}`, "error", 5000);
+      }
+    },
+    [getBrowser, loadPage, actions],
+  );
+
+  const click = useCallback(
+    async (ref: string) => {
+      const browser = getBrowser();
+      actions.setLoading(true);
+
+      try {
+        await browser.click(ref);
+        await browser.wait(500);
+        const pageData = await loadPage();
+        if (pageData) {
+          actions.setPage(pageData);
+        }
+      } catch (error) {
+        actions.setLoading(false);
+        const message = error instanceof Error ? error.message : "Unknown error";
+        actions.pushStatus(`Click failed: ${message}`, "error", 3000);
+      }
+    },
+    [getBrowser, loadPage, actions],
+  );
+
+  const back = useCallback(async () => {
+    const browser = getBrowser();
+    actions.setLoading(true);
+    actions.pushStatus("Going back...", "loading");
+
+    try {
+      await browser.back();
+      await browser.wait(500);
+      const pageData = await loadPage();
+      if (pageData) {
+        actions.setPage(pageData);
+        actions.clearStatus("loading");
+      }
+    } catch (error) {
+      actions.setLoading(false);
+      actions.clearStatus("loading");
+      const message = error instanceof Error ? error.message : "Unknown error";
+      actions.pushStatus(`Back failed: ${message}`, "error", 3000);
+    }
+  }, [getBrowser, loadPage, actions]);
+
+  const cleanup = useCallback(async () => {
+    if (browserRef.current) {
+      try {
+        await browserRef.current.close();
+      } catch {
+        // Ignore cleanup errors
+      }
+      browserRef.current = null;
+    }
+  }, []);
+
+  // Load initial URL on mount
+  useEffect(() => {
+    if (state.url && state.elements.length === 0 && !state.isLoading) {
+      navigate(state.url);
+    }
+  }, []);
+
+  return { navigate, click, back, cleanup };
+}

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -24,6 +24,8 @@ describe("useKeyboard", () => {
       inputMode: "normal",
       inputBuffer: "",
       statusMessages: [],
+      isLoading: false,
+      numberToRef: {},
     };
 
     actions = {
@@ -36,6 +38,8 @@ describe("useKeyboard", () => {
       pushStatus: vi.fn(),
       clearStatus: vi.fn(),
       setScrollOffset: vi.fn(),
+      setLoading: vi.fn(),
+      setPage: vi.fn(),
     };
   });
 

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -25,6 +25,8 @@ export interface AppState {
   inputMode: InputMode;
   inputBuffer: string;
   statusMessages: StatusMessage[];
+  isLoading: boolean;
+  numberToRef: Record<number, string>;
 }
 
 export const PRIORITY_ORDER: Record<StatusPriority, number> = {

--- a/src/state/useAppState.ts
+++ b/src/state/useAppState.ts
@@ -7,26 +7,31 @@ import type {
   StatusPriority,
 } from "./AppState.js";
 
-const MOCK_ELEMENTS: InteractiveElement[] = [
-  { ref: "1", label: 1, text: "Hacker News", type: "link" },
-  { ref: "2", label: 2, text: "new", type: "link" },
-  { ref: "3", label: 3, text: "past", type: "link" },
-  { ref: "4", label: 4, text: "comments", type: "link" },
-  { ref: "5", label: 5, text: "77 comments", type: "link" },
-  { ref: "6", label: 6, text: "161 comments", type: "link" },
-];
+const DEFAULT_HINT: StatusMessage = { text: "q:quit g:url /:search j/k:nav", priority: "hint" };
 
-const initialState: AppState = {
-  url: "https://news.ycombinator.com",
-  title: "Hacker News",
-  elements: MOCK_ELEMENTS,
-  highlightIndex: 0,
-  scrollOffset: 0,
-  totalLines: 20,
-  inputMode: "normal",
-  inputBuffer: "",
-  statusMessages: [{ text: "q:quit g:url /:search j/k:nav", priority: "hint" }],
-};
+function createInitialState(url?: string): AppState {
+  return {
+    url: url ?? "",
+    title: "",
+    elements: [],
+    highlightIndex: 0,
+    scrollOffset: 0,
+    totalLines: 0,
+    inputMode: "normal",
+    inputBuffer: "",
+    statusMessages: [DEFAULT_HINT],
+    isLoading: false,
+    numberToRef: {},
+  };
+}
+
+export interface PageData {
+  url: string;
+  title: string;
+  elements: InteractiveElement[];
+  totalLines: number;
+  numberToRef: Record<number, string>;
+}
 
 export interface AppActions {
   setHighlight: (index: number) => void;
@@ -38,10 +43,12 @@ export interface AppActions {
   pushStatus: (text: string, priority: StatusPriority, ttl?: number) => void;
   clearStatus: (priority?: StatusPriority) => void;
   setScrollOffset: (offset: number) => void;
+  setLoading: (loading: boolean) => void;
+  setPage: (data: PageData) => void;
 }
 
-export function useAppState(): [AppState, AppActions] {
-  const [state, setState] = useState<AppState>(initialState);
+export function useAppState(initialUrl?: string): [AppState, AppActions] {
+  const [state, setState] = useState<AppState>(() => createInitialState(initialUrl));
 
   const setHighlight = useCallback((index: number) => {
     setState((s) => ({
@@ -94,6 +101,24 @@ export function useAppState(): [AppState, AppActions] {
     }));
   }, []);
 
+  const setLoading = useCallback((loading: boolean) => {
+    setState((s) => ({ ...s, isLoading: loading }));
+  }, []);
+
+  const setPage = useCallback((data: PageData) => {
+    setState((s) => ({
+      ...s,
+      url: data.url,
+      title: data.title,
+      elements: data.elements,
+      totalLines: data.totalLines,
+      numberToRef: data.numberToRef,
+      highlightIndex: 0,
+      scrollOffset: 0,
+      isLoading: false,
+    }));
+  }, []);
+
   const actions: AppActions = {
     setHighlight,
     moveHighlight,
@@ -104,6 +129,8 @@ export function useAppState(): [AppState, AppActions] {
     pushStatus,
     clearStatus,
     setScrollOffset,
+    setLoading,
+    setPage,
   };
 
   return [state, actions];


### PR DESCRIPTION
## Summary
- Add CLI entry point with `tok <url>` usage (no subcommand needed)
- Add `useBrowser` hook for browser integration (navigate, click, back, cleanup)
- Connect Browser + parseSnapshot + render pipeline to App component
- Handle browser session cleanup on exit (SIGINT, SIGTERM)

## Usage
```bash
tok https://news.ycombinator.com
```

## Navigation flow
1. User starts app with URL
2. App opens URL via agent-browser
3. App gets snapshot, parses, renders to TUI
4. User clicks element (number or Enter on highlight)
5. App clicks via agent-browser, refreshes snapshot
6. Repeat

## Test plan
- [ ] `tok https://example.com` loads and displays page
- [ ] Press number key to click element
- [ ] Press `g`, type URL, press Enter to navigate
- [ ] Press `b` to go back
- [ ] Press `q` to quit (browser session cleaned up)
- [ ] Ctrl+C exits cleanly

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)