### PR TITLE
feat: add scroll support for long pages

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,13 +20,18 @@ export function App({ url }: AppProps) {
 
   const viewportHeight = stdout?.rows ? stdout.rows - 4 : 20;
 
-  useKeyboard(state, actions, {
-    onNavigate: navigate,
-    onClick: (ref) => {
-      click(ref);
+  useKeyboard(
+    state,
+    actions,
+    {
+      onNavigate: navigate,
+      onClick: (ref) => {
+        click(ref);
+      },
+      onBack: back,
     },
-    onBack: back,
-  });
+    { viewportHeight },
+  );
 
   useEffect(() => {
     return () => {
@@ -51,7 +56,12 @@ export function App({ url }: AppProps) {
   return (
     <Box flexDirection="column" height={stdout?.rows}>
       <Header title={state.title} url={state.url} />
-      <Content elements={state.elements} highlightIndex={state.highlightIndex} />
+      <Content
+        elements={state.elements}
+        highlightIndex={state.highlightIndex}
+        scrollOffset={state.scrollOffset}
+        viewportHeight={viewportHeight}
+      />
       <StatusBar
         messages={state.statusMessages}
         scrollOffset={state.scrollOffset}

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -5,13 +5,25 @@ import type { InteractiveElement } from "../state/AppState.js";
 export interface ContentProps {
   elements: InteractiveElement[];
   highlightIndex: number;
+  scrollOffset: number;
+  viewportHeight: number;
 }
 
-export function Content({ elements, highlightIndex }: ContentProps) {
+export function Content({ elements, highlightIndex, scrollOffset, viewportHeight }: ContentProps) {
+  const hasMoreAbove = scrollOffset > 0;
+  const hasMoreBelow = scrollOffset + viewportHeight < elements.length;
+
+  // Reserve 1 line for each scroll indicator when needed
+  const indicatorLines = (hasMoreAbove ? 1 : 0) + (hasMoreBelow ? 1 : 0);
+  const contentHeight = viewportHeight - indicatorLines;
+  const visibleElements = elements.slice(scrollOffset, scrollOffset + contentHeight);
+
   return (
     <Box flexDirection="column" flexGrow={1}>
-      {elements.map((element, index) => {
-        const isHighlighted = index === highlightIndex;
+      {hasMoreAbove && <Text dimColor>▲ more above ({scrollOffset} items)</Text>}
+      {visibleElements.map((element, visibleIndex) => {
+        const actualIndex = scrollOffset + visibleIndex;
+        const isHighlighted = actualIndex === highlightIndex;
         return (
           <Box key={element.ref}>
             <Text color="yellow">[{element.label}]</Text>
@@ -22,6 +34,9 @@ export function Content({ elements, highlightIndex }: ContentProps) {
           </Box>
         );
       })}
+      {hasMoreBelow && (
+        <Text dimColor>▼ more below ({elements.length - scrollOffset - contentHeight} items)</Text>
+      )}
     </Box>
   );
 }

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -40,6 +40,8 @@ describe("useKeyboard", () => {
       setScrollOffset: vi.fn(),
       setLoading: vi.fn(),
       setPage: vi.fn(),
+      scrollPage: vi.fn(),
+      scrollToEnd: vi.fn(),
     };
   });
 
@@ -51,25 +53,69 @@ describe("useKeyboard", () => {
     it("moveHighlight(1) on j key", () => {
       const { handleInput } = createKeyboardHandler(state, actions);
       handleInput("j", {});
-      expect(actions.moveHighlight).toHaveBeenCalledWith(1);
+      expect(actions.moveHighlight).toHaveBeenCalledWith(1, 20);
     });
 
     it("moveHighlight(-1) on k key", () => {
       const { handleInput } = createKeyboardHandler(state, actions);
       handleInput("k", {});
-      expect(actions.moveHighlight).toHaveBeenCalledWith(-1);
+      expect(actions.moveHighlight).toHaveBeenCalledWith(-1, 20);
     });
 
     it("moveHighlight(1) on down arrow", () => {
       const { handleInput } = createKeyboardHandler(state, actions);
       handleInput("", { downArrow: true });
-      expect(actions.moveHighlight).toHaveBeenCalledWith(1);
+      expect(actions.moveHighlight).toHaveBeenCalledWith(1, 20);
     });
 
     it("moveHighlight(-1) on up arrow", () => {
       const { handleInput } = createKeyboardHandler(state, actions);
       handleInput("", { upArrow: true });
-      expect(actions.moveHighlight).toHaveBeenCalledWith(-1);
+      expect(actions.moveHighlight).toHaveBeenCalledWith(-1, 20);
+    });
+  });
+
+  describe("scroll navigation", () => {
+    it("scrollPage down on Page Down", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("", { pageDown: true });
+      expect(actions.scrollPage).toHaveBeenCalledWith("down", 20);
+    });
+
+    it("scrollPage up on Page Up", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("", { pageUp: true });
+      expect(actions.scrollPage).toHaveBeenCalledWith("up", 20);
+    });
+
+    it("scrollPage down on Ctrl+D", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("d", { ctrl: true });
+      expect(actions.scrollPage).toHaveBeenCalledWith("down", 20);
+    });
+
+    it("scrollPage up on Ctrl+U", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("u", { ctrl: true });
+      expect(actions.scrollPage).toHaveBeenCalledWith("up", 20);
+    });
+
+    it("scrollToEnd start on Cmd+Up", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("", { meta: true, upArrow: true });
+      expect(actions.scrollToEnd).toHaveBeenCalledWith("start", 20);
+    });
+
+    it("scrollToEnd end on Cmd+Down", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("", { meta: true, downArrow: true });
+      expect(actions.scrollToEnd).toHaveBeenCalledWith("end", 20);
+    });
+
+    it("scrollToEnd end on G key", () => {
+      const { handleInput } = createKeyboardHandler(state, actions);
+      handleInput("G", {});
+      expect(actions.scrollToEnd).toHaveBeenCalledWith("end", 20);
     });
   });
 
@@ -218,6 +264,8 @@ interface KeyInfo {
   delete?: boolean;
   ctrl?: boolean;
   meta?: boolean;
+  pageUp?: boolean;
+  pageDown?: boolean;
 }
 
 interface KeyboardCallbacks {
@@ -231,6 +279,7 @@ function createKeyboardHandler(
   state: AppState,
   actions: AppActions,
   callbacks: KeyboardCallbacks = {},
+  viewportHeight: number = 20,
 ) {
   const DIGIT_TIMEOUT_MS = 300;
   let digitTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -280,13 +329,38 @@ function createKeyboardHandler(
       return;
     }
 
+    if (key.meta && key.upArrow) {
+      actions.scrollToEnd("start", viewportHeight);
+      return;
+    }
+
+    if (key.meta && key.downArrow) {
+      actions.scrollToEnd("end", viewportHeight);
+      return;
+    }
+
     if (input === "j" || key.downArrow) {
-      actions.moveHighlight(1);
+      actions.moveHighlight(1, viewportHeight);
       return;
     }
 
     if (input === "k" || key.upArrow) {
-      actions.moveHighlight(-1);
+      actions.moveHighlight(-1, viewportHeight);
+      return;
+    }
+
+    if (key.pageDown || (key.ctrl && input === "d")) {
+      actions.scrollPage("down", viewportHeight);
+      return;
+    }
+
+    if (key.pageUp || (key.ctrl && input === "u")) {
+      actions.scrollPage("up", viewportHeight);
+      return;
+    }
+
+    if (input === "G") {
+      actions.scrollToEnd("end", viewportHeight);
       return;
     }
 

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -12,11 +12,17 @@ export interface KeyboardCallbacks {
   onSearch?: (query: string) => void;
 }
 
+export interface KeyboardOptions {
+  viewportHeight: number;
+}
+
 export function useKeyboard(
   state: AppState,
   actions: AppActions,
   callbacks: KeyboardCallbacks = {},
+  options: KeyboardOptions = { viewportHeight: 20 },
 ): void {
+  const { viewportHeight } = options;
   const { exit } = useApp();
   const digitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -118,13 +124,40 @@ export function useKeyboard(
       return;
     }
 
+    // Meta+arrow for jump to start/end (check before plain arrows)
+    if (key.meta && key.upArrow) {
+      actions.scrollToEnd("start", viewportHeight);
+      return;
+    }
+
+    if (key.meta && key.downArrow) {
+      actions.scrollToEnd("end", viewportHeight);
+      return;
+    }
+
     if (input === "j" || key.downArrow) {
-      actions.moveHighlight(1);
+      actions.moveHighlight(1, viewportHeight);
       return;
     }
 
     if (input === "k" || key.upArrow) {
-      actions.moveHighlight(-1);
+      actions.moveHighlight(-1, viewportHeight);
+      return;
+    }
+
+    if (key.pageDown || (key.ctrl && input === "d")) {
+      actions.scrollPage("down", viewportHeight);
+      return;
+    }
+
+    if (key.pageUp || (key.ctrl && input === "u")) {
+      actions.scrollPage("up", viewportHeight);
+      return;
+    }
+
+    // Vim-style: G goes to end
+    if (input === "G") {
+      actions.scrollToEnd("end", viewportHeight);
       return;
     }
 

--- a/src/state/useAppState.ts
+++ b/src/state/useAppState.ts
@@ -34,8 +34,8 @@ export interface PageData {
 }
 
 export interface AppActions {
-  setHighlight: (index: number) => void;
-  moveHighlight: (delta: number) => void;
+  setHighlight: (index: number, viewportHeight?: number) => void;
+  moveHighlight: (delta: number, viewportHeight?: number) => void;
   setInputMode: (mode: InputMode) => void;
   setInputBuffer: (buffer: string) => void;
   appendToBuffer: (char: string) => void;
@@ -45,23 +45,55 @@ export interface AppActions {
   setScrollOffset: (offset: number) => void;
   setLoading: (loading: boolean) => void;
   setPage: (data: PageData) => void;
+  scrollPage: (direction: "up" | "down", viewportHeight: number) => void;
+  scrollToEnd: (position: "start" | "end", viewportHeight: number) => void;
 }
 
 export function useAppState(initialUrl?: string): [AppState, AppActions] {
   const [state, setState] = useState<AppState>(() => createInitialState(initialUrl));
 
-  const setHighlight = useCallback((index: number) => {
-    setState((s) => ({
-      ...s,
-      highlightIndex: Math.max(0, Math.min(index, s.elements.length - 1)),
-    }));
+  const setHighlight = useCallback((index: number, viewportHeight?: number) => {
+    setState((s) => {
+      const newIndex = Math.max(0, Math.min(index, s.elements.length - 1));
+      let newOffset = s.scrollOffset;
+
+      if (viewportHeight) {
+        // Auto-scroll to keep highlight visible
+        if (newIndex < newOffset) {
+          newOffset = newIndex;
+        } else if (newIndex >= newOffset + viewportHeight) {
+          newOffset = newIndex - viewportHeight + 1;
+        }
+      }
+
+      return {
+        ...s,
+        highlightIndex: newIndex,
+        scrollOffset: Math.max(0, newOffset),
+      };
+    });
   }, []);
 
-  const moveHighlight = useCallback((delta: number) => {
-    setState((s) => ({
-      ...s,
-      highlightIndex: Math.max(0, Math.min(s.highlightIndex + delta, s.elements.length - 1)),
-    }));
+  const moveHighlight = useCallback((delta: number, viewportHeight?: number) => {
+    setState((s) => {
+      const newIndex = Math.max(0, Math.min(s.highlightIndex + delta, s.elements.length - 1));
+      let newOffset = s.scrollOffset;
+
+      if (viewportHeight) {
+        // Auto-scroll to keep highlight visible
+        if (newIndex < newOffset) {
+          newOffset = newIndex;
+        } else if (newIndex >= newOffset + viewportHeight) {
+          newOffset = newIndex - viewportHeight + 1;
+        }
+      }
+
+      return {
+        ...s,
+        highlightIndex: newIndex,
+        scrollOffset: Math.max(0, newOffset),
+      };
+    });
   }, []);
 
   const setInputMode = useCallback((mode: InputMode) => {
@@ -97,7 +129,7 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
   const setScrollOffset = useCallback((offset: number) => {
     setState((s) => ({
       ...s,
-      scrollOffset: Math.max(0, Math.min(offset, Math.max(0, s.totalLines - 1))),
+      scrollOffset: Math.max(0, Math.min(offset, Math.max(0, s.elements.length - 1))),
     }));
   }, []);
 
@@ -119,6 +151,49 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
     }));
   }, []);
 
+  const scrollPage = useCallback((direction: "up" | "down", viewportHeight: number) => {
+    setState((s) => {
+      const pageSize = Math.max(1, viewportHeight - 1);
+      const delta = direction === "down" ? pageSize : -pageSize;
+      const maxOffset = Math.max(0, s.elements.length - viewportHeight);
+      const newOffset = Math.max(0, Math.min(s.scrollOffset + delta, maxOffset));
+
+      // Move highlight to stay in visible area
+      let newHighlight = s.highlightIndex;
+      if (newHighlight < newOffset) {
+        newHighlight = newOffset;
+      } else if (newHighlight >= newOffset + viewportHeight) {
+        newHighlight = newOffset + viewportHeight - 1;
+      }
+      newHighlight = Math.max(0, Math.min(newHighlight, s.elements.length - 1));
+
+      return {
+        ...s,
+        scrollOffset: newOffset,
+        highlightIndex: newHighlight,
+      };
+    });
+  }, []);
+
+  const scrollToEnd = useCallback((position: "start" | "end", viewportHeight: number) => {
+    setState((s) => {
+      if (position === "start") {
+        return {
+          ...s,
+          scrollOffset: 0,
+          highlightIndex: 0,
+        };
+      } else {
+        const maxOffset = Math.max(0, s.elements.length - viewportHeight);
+        return {
+          ...s,
+          scrollOffset: maxOffset,
+          highlightIndex: s.elements.length - 1,
+        };
+      }
+    });
+  }, []);
+
   const actions: AppActions = {
     setHighlight,
     moveHighlight,
@@ -131,6 +206,8 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
     setScrollOffset,
     setLoading,
     setPage,
+    scrollPage,
+    scrollToEnd,
   };
 
   return [state, actions];


### PR DESCRIPTION
## Summary
- Add viewport clipping in Content component with scroll indicators ("▲ more above" / "▼ more below")
- Implement auto-scroll when highlight moves out of visible viewport
- Add keyboard shortcuts: Page Up/Down, Ctrl+D/U, Cmd+Up/Down, and G (vim-style end)
- Update state management with `scrollPage` and `scrollToEnd` actions

Closes #9

## Test plan
- [x] All existing tests pass
- [x] New scroll navigation tests added
- [ ] Manual test: scroll through long content with j/k keys
- [ ] Manual test: Page Up/Down jumps by viewport size
- [ ] Manual test: G jumps to end, Cmd+Up jumps to start
- [ ] Manual test: scroll indicators appear when content exceeds viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)