### PR TITLE
feat: improve content display with structured snapshot parsing (#23)

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -57,8 +57,8 @@ export function App({ url }: AppProps) {
     <Box flexDirection="column" height={stdout?.rows}>
       <Header title={state.title} url={state.url} />
       <Content
-        elements={state.elements}
-        highlightIndex={state.highlightIndex}
+        displayLines={state.displayLines}
+        highlightNumber={state.elements[state.highlightIndex]?.label}
         scrollOffset={state.scrollOffset}
         viewportHeight={viewportHeight}
       />

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,41 +1,57 @@
 import React from "react";
 import { Box, Text } from "ink";
-import type { InteractiveElement } from "../state/AppState.js";
+import type { DisplayLine } from "../state/AppState.js";
 
 export interface ContentProps {
-  elements: InteractiveElement[];
-  highlightIndex: number;
+  displayLines: DisplayLine[];
+  highlightNumber: number | undefined;
   scrollOffset: number;
   viewportHeight: number;
 }
 
-export function Content({ elements, highlightIndex, scrollOffset, viewportHeight }: ContentProps) {
+export function Content({
+  displayLines,
+  highlightNumber,
+  scrollOffset,
+  viewportHeight,
+}: ContentProps) {
   const hasMoreAbove = scrollOffset > 0;
-  const hasMoreBelow = scrollOffset + viewportHeight < elements.length;
+  const hasMoreBelow = scrollOffset + viewportHeight < displayLines.length;
 
   // Reserve 1 line for each scroll indicator when needed
   const indicatorLines = (hasMoreAbove ? 1 : 0) + (hasMoreBelow ? 1 : 0);
   const contentHeight = viewportHeight - indicatorLines;
-  const visibleElements = elements.slice(scrollOffset, scrollOffset + contentHeight);
+  const visibleLines = displayLines.slice(scrollOffset, scrollOffset + contentHeight);
 
   return (
     <Box flexDirection="column" flexGrow={1}>
-      {hasMoreAbove && <Text dimColor>▲ more above ({scrollOffset} items)</Text>}
-      {visibleElements.map((element, visibleIndex) => {
-        const actualIndex = scrollOffset + visibleIndex;
-        const isHighlighted = actualIndex === highlightIndex;
-        return (
-          <Box key={element.ref}>
-            <Text color="yellow">[{element.label}]</Text>
-            <Text> </Text>
-            <Text inverse={isHighlighted} bold={isHighlighted}>
-              {element.text}
-            </Text>
-          </Box>
-        );
+      {hasMoreAbove && <Text dimColor>▲ more above ({scrollOffset} lines)</Text>}
+      {visibleLines.map((line, visibleIndex) => {
+        const lineIndex = scrollOffset + visibleIndex;
+        const isHighlighted = line.interactive && line.number === highlightNumber;
+
+        if (line.interactive && line.number !== undefined) {
+          // Interactive line - show number in yellow, highlight if selected
+          return (
+            <Box key={lineIndex}>
+              <Text inverse={isHighlighted} bold={isHighlighted}>
+                {line.text}
+              </Text>
+            </Box>
+          );
+        } else {
+          // Non-interactive line - dimmed
+          return (
+            <Box key={lineIndex}>
+              <Text dimColor>{line.text}</Text>
+            </Box>
+          );
+        }
       })}
       {hasMoreBelow && (
-        <Text dimColor>▼ more below ({elements.length - scrollOffset - contentHeight} items)</Text>
+        <Text dimColor>
+          ▼ more below ({displayLines.length - scrollOffset - contentHeight} lines)
+        </Text>
       )}
     </Box>
   );

--- a/src/hooks/useBrowser.ts
+++ b/src/hooks/useBrowser.ts
@@ -27,7 +27,7 @@ export function useBrowser(
     const browser = getBrowser();
     try {
       const [snapshot, url, title] = await Promise.all([
-        browser.snapshot({ interactive: true }),
+        browser.snapshot(),
         browser.getUrl(),
         browser.getTitle(),
       ]);
@@ -48,6 +48,7 @@ export function useBrowser(
         url,
         title,
         elements,
+        displayLines: result.lines,
         totalLines: result.lines.length,
         numberToRef: result.numberToRef,
       };

--- a/src/hooks/useKeyboard.test.ts
+++ b/src/hooks/useKeyboard.test.ts
@@ -18,6 +18,12 @@ describe("useKeyboard", () => {
         { ref: "c", label: 10, text: "Link 10", type: "link" },
         { ref: "d", label: 11, text: "Link 11", type: "link" },
       ],
+      displayLines: [
+        { text: "[1] Link 1", interactive: true, number: 1 },
+        { text: "[2] Link 2", interactive: true, number: 2 },
+        { text: "[10] Link 10", interactive: true, number: 10 },
+        { text: "[11] Link 11", interactive: true, number: 11 },
+      ],
       highlightIndex: 0,
       scrollOffset: 0,
       totalLines: 10,

--- a/src/renderer.test.ts
+++ b/src/renderer.test.ts
@@ -197,9 +197,12 @@ describe("render", () => {
     ];
     const result = render(nodes);
 
-    expect(result.lines).toContainEqual({ text: "Click ", interactive: false });
-    expect(result.lines).toContainEqual({ text: "[1] here", interactive: true, number: 1 });
-    expect(result.lines).toContainEqual({ text: " to continue.", interactive: false });
+    // Paragraph content is now combined into a single line
+    expect(result.lines).toContainEqual({
+      text: "Click [1] here to continue.",
+      interactive: true,
+      number: 1,
+    });
   });
 
   it("removes consecutive empty lines", () => {
@@ -262,5 +265,161 @@ describe("render", () => {
     expect(result.lines).toContainEqual({ text: "Name", interactive: false });
     expect(result.lines).toContainEqual({ text: "Agree", interactive: false });
     expect(Object.keys(result.numberToRef)).toHaveLength(0);
+  });
+
+  it("renders table row with multiple cells horizontally", () => {
+    const nodes: SnapshotNode[] = [
+      {
+        type: "table",
+        children: [
+          {
+            type: "row",
+            children: [
+              {
+                type: "cell",
+                children: [{ type: "link", name: "Home", ref: "e1", children: [] }],
+              },
+              {
+                type: "cell",
+                children: [{ type: "link", name: "About", ref: "e2", children: [] }],
+              },
+              {
+                type: "cell",
+                children: [{ type: "link", name: "Contact", ref: "e3", children: [] }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = render(nodes);
+
+    // All nav items should be on one line
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0]?.text).toBe("[1] Home  [2] About  [3] Contact");
+    expect(result.lines[0]?.interactive).toBe(true);
+    expect(result.numberToRef).toEqual({ 1: "e1", 2: "e2", 3: "e3" });
+  });
+
+  it("renders table with static text and links in cells", () => {
+    const nodes: SnapshotNode[] = [
+      {
+        type: "table",
+        children: [
+          {
+            type: "row",
+            children: [
+              {
+                type: "cell",
+                children: [{ type: "StaticText", name: "1.", children: [] }],
+              },
+              {
+                type: "cell",
+                children: [
+                  { type: "link", name: "Article Title", ref: "e1", children: [] },
+                  { type: "StaticText", name: " (example.com)", children: [] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0]?.text).toBe("1.  [1] Article Title   (example.com)");
+  });
+
+  it("renders list with items horizontally grouped", () => {
+    const nodes: SnapshotNode[] = [
+      {
+        type: "list",
+        children: [
+          {
+            type: "listitem",
+            children: [
+              { type: "StaticText", name: "100 points by ", children: [] },
+              { type: "link", name: "user1", ref: "e1", children: [] },
+              { type: "StaticText", name: " | ", children: [] },
+              { type: "link", name: "50 comments", ref: "e2", children: [] },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toHaveLength(1);
+    expect(result.lines[0]?.text).toBe("100 points by   [1] user1   |   [2] 50 comments");
+  });
+
+  it("renders multiple table rows as separate lines", () => {
+    const nodes: SnapshotNode[] = [
+      {
+        type: "table",
+        children: [
+          {
+            type: "row",
+            children: [
+              {
+                type: "cell",
+                children: [{ type: "link", name: "First Article", ref: "e1", children: [] }],
+              },
+            ],
+          },
+          {
+            type: "row",
+            children: [
+              {
+                type: "cell",
+                children: [
+                  { type: "StaticText", name: "10 points by ", children: [] },
+                  { type: "link", name: "author", ref: "e2", children: [] },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toHaveLength(2);
+    expect(result.lines[0]?.text).toBe("[1] First Article");
+    expect(result.lines[1]?.text).toBe("10 points by   [2] author");
+  });
+
+  it("renders Hacker News style navigation", () => {
+    const nodes: SnapshotNode[] = [
+      {
+        type: "navigation",
+        children: [
+          {
+            type: "list",
+            children: [
+              {
+                type: "listitem",
+                children: [{ type: "link", name: "new", ref: "e1", children: [] }],
+              },
+              {
+                type: "listitem",
+                children: [{ type: "link", name: "past", ref: "e2", children: [] }],
+              },
+              {
+                type: "listitem",
+                children: [{ type: "link", name: "comments", ref: "e3", children: [] }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = render(nodes);
+
+    expect(result.lines).toHaveLength(3);
+    expect(result.lines[0]?.text).toBe("[1] new");
+    expect(result.lines[1]?.text).toBe("[2] past");
+    expect(result.lines[2]?.text).toBe("[3] comments");
   });
 });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -127,6 +127,148 @@ interface RenderContext {
   nextNumber: number;
 }
 
+// Collect inline content from a node and its children into segments
+interface Segment {
+  text: string;
+  interactive: boolean;
+  number?: number;
+  ref?: string;
+}
+
+function collectInlineSegments(node: SnapshotNode, ctx: RenderContext): Segment[] {
+  const segments: Segment[] = [];
+
+  // Handle static text
+  if (node.type === "StaticText") {
+    const text = node.name ?? "";
+    if (text) {
+      segments.push({ text, interactive: false });
+    }
+    return segments;
+  }
+
+  // Handle interactive elements with ref
+  if (isInteractive(node)) {
+    const number = ctx.nextNumber++;
+    const ref = node.ref!;
+    ctx.numberToRef[number] = ref;
+    const segment: Segment = {
+      text: formatInteractive(node, number),
+      interactive: true,
+      number,
+      ref,
+    };
+    segments.push(segment);
+    // Options in combobox are handled separately (not inline)
+    return segments;
+  }
+
+  // Handle interactive elements without ref - display as plain text
+  if (INTERACTIVE_TYPES.has(node.type)) {
+    const text = node.name ?? "";
+    if (text) {
+      segments.push({ text, interactive: false });
+    }
+    return segments;
+  }
+
+  // For other elements, collect from children
+  for (const child of node.children) {
+    segments.push(...collectInlineSegments(child, ctx));
+  }
+
+  return segments;
+}
+
+// Render a row as a single line with elements separated by spaces
+function renderRow(node: SnapshotNode, ctx: RenderContext, prefix: string = ""): void {
+  const segments: Segment[] = [];
+
+  for (const cell of node.children) {
+    const cellSegments = collectInlineSegments(cell, ctx);
+    segments.push(...cellSegments);
+  }
+
+  if (segments.length === 0) return;
+
+  // Join segments with appropriate spacing
+  const parts: string[] = [];
+  let hasInteractive = false;
+  let firstInteractiveNumber: number | undefined;
+
+  for (const seg of segments) {
+    if (seg.interactive) {
+      hasInteractive = true;
+      if (firstInteractiveNumber === undefined) {
+        firstInteractiveNumber = seg.number;
+      }
+    }
+    parts.push(seg.text);
+  }
+
+  const text = prefix + parts.join("  ");
+  const line: DisplayLine = { text, interactive: hasInteractive };
+  if (firstInteractiveNumber !== undefined) {
+    line.number = firstInteractiveNumber;
+  }
+  ctx.lines.push(line);
+}
+
+// Render a table structure
+function renderTable(node: SnapshotNode, ctx: RenderContext): void {
+  for (const child of node.children) {
+    if (child.type === "row") {
+      renderRow(child, ctx);
+    } else if (child.type === "rowgroup") {
+      // Handle rowgroup (thead, tbody, tfoot)
+      for (const row of child.children) {
+        if (row.type === "row") {
+          renderRow(row, ctx);
+        }
+      }
+    } else {
+      renderNode(child, ctx);
+    }
+  }
+}
+
+// Render a list structure
+function renderList(node: SnapshotNode, ctx: RenderContext, ordered: boolean = false): void {
+  let itemNumber = 1;
+  for (const child of node.children) {
+    if (child.type === "listitem") {
+      const prefix = ordered ? `${itemNumber}. ` : "";
+      const segments = collectInlineSegments(child, ctx);
+
+      if (segments.length > 0) {
+        const parts: string[] = [];
+        let hasInteractive = false;
+        let firstInteractiveNumber: number | undefined;
+
+        for (const seg of segments) {
+          if (seg.interactive) {
+            hasInteractive = true;
+            if (firstInteractiveNumber === undefined) {
+              firstInteractiveNumber = seg.number;
+            }
+          }
+          parts.push(seg.text);
+        }
+
+        const text = prefix + parts.join("  ");
+        const line: DisplayLine = { text, interactive: hasInteractive };
+        if (firstInteractiveNumber !== undefined) {
+          line.number = firstInteractiveNumber;
+        }
+        ctx.lines.push(line);
+      }
+      itemNumber++;
+    } else {
+      renderNode(child, ctx);
+    }
+  }
+}
+
 function renderNode(node: SnapshotNode, ctx: RenderContext): void {
   // Handle headings
   if (node.type === "heading") {
@@ -135,15 +277,57 @@ function renderNode(node: SnapshotNode, ctx: RenderContext): void {
     return;
   }
 
+  // Handle tables
+  if (node.type === "table") {
+    renderTable(node, ctx);
+    return;
+  }
+
+  // Handle lists
+  if (node.type === "list") {
+    renderList(node, ctx, false);
+    return;
+  }
+
+  // Handle rows outside of tables
+  if (node.type === "row") {
+    renderRow(node, ctx);
+    return;
+  }
+
   // Handle static text
-  if (node.type === "StaticText" || node.type === "paragraph") {
+  if (node.type === "StaticText") {
     const text = node.name ?? "";
     if (text) {
       ctx.lines.push({ text, interactive: false });
     }
-    // Render children for paragraph
-    for (const child of node.children) {
-      renderNode(child, ctx);
+    return;
+  }
+
+  // Handle paragraph - collect inline content
+  if (node.type === "paragraph") {
+    const segments = collectInlineSegments(node, ctx);
+    if (segments.length > 0) {
+      const parts: string[] = [];
+      let hasInteractive = false;
+      let firstInteractiveNumber: number | undefined;
+
+      for (const seg of segments) {
+        if (seg.interactive) {
+          hasInteractive = true;
+          if (firstInteractiveNumber === undefined) {
+            firstInteractiveNumber = seg.number;
+          }
+        }
+        parts.push(seg.text);
+      }
+
+      const text = parts.join("");
+      const line: DisplayLine = { text, interactive: hasInteractive };
+      if (firstInteractiveNumber !== undefined) {
+        line.number = firstInteractiveNumber;
+      }
+      ctx.lines.push(line);
     }
     return;
   }

--- a/src/state/AppState.ts
+++ b/src/state/AppState.ts
@@ -15,10 +15,17 @@ export interface InteractiveElement {
   type: "link" | "button";
 }
 
+export interface DisplayLine {
+  text: string;
+  interactive: boolean;
+  number?: number;
+}
+
 export interface AppState {
   url: string;
   title: string;
   elements: InteractiveElement[];
+  displayLines: DisplayLine[];
   highlightIndex: number;
   scrollOffset: number;
   totalLines: number;

--- a/src/state/useAppState.ts
+++ b/src/state/useAppState.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import type {
   AppState,
+  DisplayLine,
   InputMode,
   InteractiveElement,
   StatusMessage,
@@ -14,6 +15,7 @@ function createInitialState(url?: string): AppState {
     url: url ?? "",
     title: "",
     elements: [],
+    displayLines: [],
     highlightIndex: 0,
     scrollOffset: 0,
     totalLines: 0,
@@ -29,6 +31,7 @@ export interface PageData {
   url: string;
   title: string;
   elements: InteractiveElement[];
+  displayLines: DisplayLine[];
   totalLines: number;
   numberToRef: Record<number, string>;
 }
@@ -129,7 +132,7 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
   const setScrollOffset = useCallback((offset: number) => {
     setState((s) => ({
       ...s,
-      scrollOffset: Math.max(0, Math.min(offset, Math.max(0, s.elements.length - 1))),
+      scrollOffset: Math.max(0, Math.min(offset, Math.max(0, s.displayLines.length - 1))),
     }));
   }, []);
 
@@ -143,6 +146,7 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
       url: data.url,
       title: data.title,
       elements: data.elements,
+      displayLines: data.displayLines,
       totalLines: data.totalLines,
       numberToRef: data.numberToRef,
       highlightIndex: 0,
@@ -155,17 +159,32 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
     setState((s) => {
       const pageSize = Math.max(1, viewportHeight - 1);
       const delta = direction === "down" ? pageSize : -pageSize;
-      const maxOffset = Math.max(0, s.elements.length - viewportHeight);
+      const maxOffset = Math.max(0, s.displayLines.length - viewportHeight);
       const newOffset = Math.max(0, Math.min(s.scrollOffset + delta, maxOffset));
 
-      // Move highlight to stay in visible area
+      // Find first interactive line in visible area for highlight
       let newHighlight = s.highlightIndex;
-      if (newHighlight < newOffset) {
-        newHighlight = newOffset;
-      } else if (newHighlight >= newOffset + viewportHeight) {
-        newHighlight = newOffset + viewportHeight - 1;
+      const visibleStart = newOffset;
+      const visibleEnd = Math.min(newOffset + viewportHeight, s.displayLines.length);
+
+      // Check if current highlight is still visible
+      const highlightLineIndex = s.displayLines.findIndex(
+        (line) => line.interactive && line.number === s.elements[s.highlightIndex]?.label,
+      );
+
+      if (highlightLineIndex < visibleStart || highlightLineIndex >= visibleEnd) {
+        // Find first interactive element in visible area
+        for (let i = visibleStart; i < visibleEnd; i++) {
+          const line = s.displayLines[i];
+          if (line?.interactive && line.number !== undefined) {
+            const elemIdx = s.elements.findIndex((e) => e.label === line.number);
+            if (elemIdx >= 0) {
+              newHighlight = elemIdx;
+              break;
+            }
+          }
+        }
       }
-      newHighlight = Math.max(0, Math.min(newHighlight, s.elements.length - 1));
 
       return {
         ...s,
@@ -184,7 +203,7 @@ export function useAppState(initialUrl?: string): [AppState, AppActions] {
           highlightIndex: 0,
         };
       } else {
-        const maxOffset = Math.max(0, s.elements.length - viewportHeight);
+        const maxOffset = Math.max(0, s.displayLines.length - viewportHeight);
         return {
           ...s,
           scrollOffset: maxOffset,


### PR DESCRIPTION
## Summary

- Use full DOM snapshot instead of interactive-only mode to preserve structural information
- Update renderer to handle table/row/cell and list/listitem structures
- Group content horizontally within rows (nav items, article metadata)
- Display static text inline with interactive elements in paragraphs
- Update Content component to render all display lines, not just interactive elements

Closes #23

## Test plan

- [x] All existing tests pass
- [x] New tests added for table/row/cell rendering
- [x] New tests added for list rendering
- [x] TypeScript type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)